### PR TITLE
Make mobile css occur earlier

### DIFF
--- a/css/output.css
+++ b/css/output.css
@@ -1,4 +1,6 @@
-*, ::before, ::after {
+*,
+::before,
+::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;
@@ -8,19 +10,19 @@
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -28,28 +30,28 @@
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
 }
 
 ::backdrop {
@@ -62,19 +64,19 @@
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -82,28 +84,28 @@
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
 }
 
 /*
@@ -130,7 +132,7 @@
 
 ::before,
 ::after {
-  --tw-content: '';
+  --tw-content: "";
 }
 
 /*
@@ -152,9 +154,10 @@ html,
   -moz-tab-size: 4;
   /* 3 */
   -o-tab-size: 4;
-     tab-size: 4;
+  tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -197,7 +200,7 @@ Add the correct text decoration in Chrome, Edge, and Safari.
 
 abbr:where([title]) {
   -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
 }
 
 /*
@@ -243,7 +246,8 @@ code,
 kbd,
 samp,
 pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
   /* 1 */
   font-feature-settings: normal;
   /* 2 */
@@ -344,9 +348,9 @@ select {
 */
 
 button,
-input:where([type='button']),
-input:where([type='reset']),
-input:where([type='submit']) {
+input:where([type="button"]),
+input:where([type="reset"]),
+input:where([type="submit"]) {
   -webkit-appearance: button;
   /* 1 */
   background-color: transparent;
@@ -393,7 +397,7 @@ Correct the cursor style of increment and decrement buttons in Safari.
 2. Correct the outline style in Safari.
 */
 
-[type='search'] {
+[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
   outline-offset: -2px;
@@ -486,7 +490,8 @@ textarea {
 2. Set the default placeholder color to the user's configured gray 400 color.
 */
 
-input::-moz-placeholder, textarea::-moz-placeholder {
+input::-moz-placeholder,
+textarea::-moz-placeholder {
   opacity: 1;
   /* 1 */
   color: #9ca3af;
@@ -580,7 +585,7 @@ video {
   font-family: "latin-mono-cond-oblique";
 
   src: url("../webAssets/fonts/lmmonoltcond10-oblique-webfont.woff")
-      format("woff");
+    format("woff");
 
   font-weight: normal;
 
@@ -758,7 +763,9 @@ video {
 }
 
 .transform {
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y))
+    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
+    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .resize {
@@ -999,18 +1006,26 @@ video {
 }
 
 .filter {
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast)
+    var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate)
+    var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color,
+    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
+    -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color,
+    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
+    backdrop-filter;
+  transition-property: color, background-color, border-color,
+    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
+    backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
-@media (min-width: 640px) {
+@media (min-width: 1024px) {
   .sm\:-right-96 {
     right: -24rem;
   }

--- a/css/output.css
+++ b/css/output.css
@@ -1,6 +1,4 @@
-*,
-::before,
-::after {
+*, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;
@@ -10,19 +8,19 @@
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x: ;
-  --tw-pan-y: ;
-  --tw-pinch-zoom: ;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position: ;
-  --tw-gradient-via-position: ;
-  --tw-gradient-to-position: ;
-  --tw-ordinal: ;
-  --tw-slashed-zero: ;
-  --tw-numeric-figure: ;
-  --tw-numeric-spacing: ;
-  --tw-numeric-fraction: ;
-  --tw-ring-inset: ;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -30,28 +28,28 @@
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-  --tw-drop-shadow: ;
-  --tw-backdrop-blur: ;
-  --tw-backdrop-brightness: ;
-  --tw-backdrop-contrast: ;
-  --tw-backdrop-grayscale: ;
-  --tw-backdrop-hue-rotate: ;
-  --tw-backdrop-invert: ;
-  --tw-backdrop-opacity: ;
-  --tw-backdrop-saturate: ;
-  --tw-backdrop-sepia: ;
-  --tw-contain-size: ;
-  --tw-contain-layout: ;
-  --tw-contain-paint: ;
-  --tw-contain-style: ;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
 }
 
 ::backdrop {
@@ -64,19 +62,19 @@
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x: ;
-  --tw-pan-y: ;
-  --tw-pinch-zoom: ;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position: ;
-  --tw-gradient-via-position: ;
-  --tw-gradient-to-position: ;
-  --tw-ordinal: ;
-  --tw-slashed-zero: ;
-  --tw-numeric-figure: ;
-  --tw-numeric-spacing: ;
-  --tw-numeric-fraction: ;
-  --tw-ring-inset: ;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -84,28 +82,28 @@
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-  --tw-drop-shadow: ;
-  --tw-backdrop-blur: ;
-  --tw-backdrop-brightness: ;
-  --tw-backdrop-contrast: ;
-  --tw-backdrop-grayscale: ;
-  --tw-backdrop-hue-rotate: ;
-  --tw-backdrop-invert: ;
-  --tw-backdrop-opacity: ;
-  --tw-backdrop-saturate: ;
-  --tw-backdrop-sepia: ;
-  --tw-contain-size: ;
-  --tw-contain-layout: ;
-  --tw-contain-paint: ;
-  --tw-contain-style: ;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
 }
 
 /*
@@ -132,7 +130,7 @@
 
 ::before,
 ::after {
-  --tw-content: "";
+  --tw-content: '';
 }
 
 /*
@@ -154,10 +152,9 @@ html,
   -moz-tab-size: 4;
   /* 3 */
   -o-tab-size: 4;
-  tab-size: 4;
+     tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -200,7 +197,7 @@ Add the correct text decoration in Chrome, Edge, and Safari.
 
 abbr:where([title]) {
   -webkit-text-decoration: underline dotted;
-  text-decoration: underline dotted;
+          text-decoration: underline dotted;
 }
 
 /*
@@ -246,8 +243,7 @@ code,
 kbd,
 samp,
 pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   /* 1 */
   font-feature-settings: normal;
   /* 2 */
@@ -348,9 +344,9 @@ select {
 */
 
 button,
-input:where([type="button"]),
-input:where([type="reset"]),
-input:where([type="submit"]) {
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
   -webkit-appearance: button;
   /* 1 */
   background-color: transparent;
@@ -397,7 +393,7 @@ Correct the cursor style of increment and decrement buttons in Safari.
 2. Correct the outline style in Safari.
 */
 
-[type="search"] {
+[type='search'] {
   -webkit-appearance: textfield;
   /* 1 */
   outline-offset: -2px;
@@ -490,8 +486,7 @@ textarea {
 2. Set the default placeholder color to the user's configured gray 400 color.
 */
 
-input::-moz-placeholder,
-textarea::-moz-placeholder {
+input::-moz-placeholder, textarea::-moz-placeholder {
   opacity: 1;
   /* 1 */
   color: #9ca3af;
@@ -585,7 +580,7 @@ video {
   font-family: "latin-mono-cond-oblique";
 
   src: url("../webAssets/fonts/lmmonoltcond10-oblique-webfont.woff")
-    format("woff");
+      format("woff");
 
   font-weight: normal;
 
@@ -763,9 +758,7 @@ video {
 }
 
 .transform {
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .resize {
@@ -1006,21 +999,13 @@ video {
 }
 
 .filter {
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast)
-    var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate)
-    var(--tw-sepia) var(--tw-drop-shadow);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .transition {
-  transition-property: color, background-color, border-color,
-    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-    -webkit-backdrop-filter;
-  transition-property: color, background-color, border-color,
-    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-    backdrop-filter;
-  transition-property: color, background-color, border-color,
-    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-    backdrop-filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }

--- a/index.html
+++ b/index.html
@@ -1,292 +1,211 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="./css/output.css" rel="stylesheet" />
 
-    <!-- prevent visible alpinejs page reloading -->
-    <style>
-      [x-cloak] {
-        display: none;
-      }
-    </style>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="./css/output.css" rel="stylesheet" />
 
-    <!-- SEO Meta Tags -->
-    <title>CS Webring</title>
-    <meta
-      name="description"
-      content="A webring for Computer Science students and alumni at the University of Waterloo."
-    />
-    <meta
-      name="keywords"
-      content="webring, UWaterloo, Computer Science, CS, personal websites, student portfolio"
-    />
+  <!-- prevent visible alpinejs page reloading -->
+  <style>
+    [x-cloak] {
+      display: none;
+    }
+  </style>
 
-    <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://cs.uwatering.com/" />
-    <meta property="og:title" content="CS Webring" />
-    <meta
-      property="og:description"
-      content="A webring for Computer Science students and alumni at the University of Waterloo."
-    />
-    <meta
-      property="og:image"
-      content="https://cs.uwatering.com/webAssets/og.png"
-    />
-    <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://cs.uwatering.com/" />
-    <meta property="twitter:title" content="CS Webring" />
-    <meta
-      property="twitter:description"
-      content="A webring for Computer Science students and alumni at the University of Waterloo."
-    />
-    <meta
-      property="twitter:image"
-      content="https://cs.uwatering.com/webAssets/og.png"
-    />
+  <!-- SEO Meta Tags -->
+  <title>CS Webring</title>
+  <meta name="description" content="A webring for Computer Science students and alumni at the University of Waterloo.">
+  <meta name="keywords" content="webring, UWaterloo, Computer Science, CS, personal websites, student portfolio">
 
-    <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="./webAssets/favicon.ico" />
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://cs.uwatering.com/">
+  <meta property="og:title" content="CS Webring">
+  <meta property="og:description"
+    content="A webring for Computer Science students and alumni at the University of Waterloo.">
+  <meta property="og:image" content="https://cs.uwatering.com/webAssets/og.png">
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://cs.uwatering.com/">
+  <meta property="twitter:title" content="CS Webring">
+  <meta property="twitter:description"
+    content="A webring for Computer Science students and alumni at the University of Waterloo.">
+  <meta property="twitter:image" content="https://cs.uwatering.com/webAssets/og.png">
 
-    <!-- JS sources -->
-    <script src="//unpkg.com/alpinejs" defer></script>
-    <script src="https://d3js.org/d3.v7.min.js"></script>
-    <!-- ↓↓↓ OPEN THIS GUY UP ↓↓↓ -->
-    <script>
-      const webringData = {
-        sites: [
-          {
-            name: "Justin Gu",
-            year: 2026,
-            website: "https://justin.run",
-          },
-          {
-            name: "Jaiden Ratti",
-            year: 2026,
-            website: "https://www.jaidenratti.com/",
-          },
-          {
-            name: "George Shao",
-            year: 2026,
-            website: "https://shao.zip",
-          },
-          {
-            name: "Jaryd Diamond",
-            year: 2026,
-            website: "https://jaryddiamond.com",
-          },
-          {
-            name: "Ivy Fan-Chiang",
-            year: 2027,
-            website: "https://ivyfanchiang.ca",
-          },
-          {
-            name: "Wilbur Zhang",
-            year: 2026,
-            website: "https://wilburzhang.com",
-          },
-          // TODO: allow search to work with trailing slash
-          {
-            name: "Ching Lam Lau",
-            year: 2029,
-            website: "https://chinglamlau.ca",
-          },
-          {
-            name: "Martin Sit",
-            year: 2029,
-            website: "https://martinsit.ca/",
-          },
-          {
-            name: "Kevin Huang",
-            year: 2026,
-            website: "https://kevinh.cv",
-          },
-          {
-            name: "Freeman Jiang",
-            year: 2026,
-            website: "https://freemanjiang.com",
-          },
-          {
-            name: "Aryaman Dhingra",
-            year: 2025,
-            website: "https://aryaman.dev",
-          },
-          {
-            name: "gaurav talreja",
-            year: 2025,
-            website: "https://gaurav.fyi",
-          },
-          {
-            name: "Dundee Zhang",
-            website: "https://dundeezhang.com",
-            year: "2029",
-          },
-          {
-            name: "Sean Zhang",
-            website: "https://seanzhang.ca",
-            year: 2024,
-          },
-          // ↑ ADD YOUR SITE ABOVE ↑
-          // https://github.com/JusGu/uwatering
-        ],
-      };
-    </script>
-    <!-- ↑↑↑ -->
-    <script src="./javascript/script.js"></script>
-    <script src="./javascript/d3-ring-chart.js"></script>
-  </head>
+  <!-- Favicon -->
+  <link rel="icon" type="image/x-icon" href="./webAssets/favicon.ico">
 
-  <body class="bg-mustard-100">
-    <main
-      class="text-black-900 px-2 py-6 sm:p-6 sm:min-h-[100vh] sm:w-[100vw] overflow-x-hidden"
-    >
-      <header class="hidden sm:block">
-        <img src="webAssets/logoOnWhite.svg" alt="Webring light theme logo" />
-      </header>
-      <div class="sm:hidden fixed top-6 left-0 w-full px-2">
-        <input
-          type="text"
-          id="search-mobile"
-          placeholder="Search by name, year or url..."
-          class="w-full font-latinMonoCaps px-4 py-2 border border-lime-700 rounded-none"
-        />
+  <!-- JS sources -->
+  <script src="//unpkg.com/alpinejs" defer></script>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <!-- ↓↓↓ OPEN THIS GUY UP ↓↓↓ -->
+  <script>
+    const webringData = {
+      "sites": [
+        {
+          "name": "Justin Gu",
+          "year": 2026,
+          "website": "https://justin.run"
+        },
+        {
+          "name": "Jaiden Ratti",
+          "year": 2026,
+          "website": "https://www.jaidenratti.com/"
+        },
+        {
+          "name": "George Shao",
+          "year": 2026,
+          "website": "https://shao.zip"
+        },
+        {
+          "name": "Jaryd Diamond",
+          "year": 2026,
+          "website": "https://jaryddiamond.com"
+        },
+        {
+          "name": "Ivy Fan-Chiang",
+          "year": 2027,
+          "website": "https://ivyfanchiang.ca"
+        },
+        {
+          "name": "Wilbur Zhang",
+          "year": 2026,
+          "website": "https://wilburzhang.com"
+        },
+        // TODO: allow search to work with trailing slash
+        {
+          "name": "Ching Lam Lau",
+          "year": 2029,
+          "website": "https://chinglamlau.ca"
+        },
+        {
+          "name": "Martin Sit",
+          "year": 2029,
+          "website": "https://martinsit.ca/"
+        },
+        {
+          "name": "Kevin Huang",
+          "year": 2026,
+          "website": "https://kevinh.cv"
+        },
+        {
+          "name": "Freeman Jiang",
+          "year": 2026,
+          "website": "https://freemanjiang.com"
+        },
+        {
+          "name": "Aryaman Dhingra",
+          "year": 2025,
+          "website": "https://aryaman.dev"
+        },
+        {
+          "name": "gaurav talreja",
+          "year": 2025,
+          "website": "https://gaurav.fyi"
+        },
+        {
+          "name": "Dundee Zhang",
+          "website": "https://dundeezhang.com",
+          "year": "2029"
+        },
+        {
+          "name": "Sean Zhang",
+          "website": "https://seanzhang.ca",
+          "year": 2024
+        },
+        // ↑ ADD YOUR SITE ABOVE ↑
+        // https://github.com/JusGu/uwatering
+      ]
+    };
+  </script>
+  <!-- ↑↑↑ -->
+  <script src="./javascript/script.js"></script>
+  <script src="./javascript/d3-ring-chart.js"></script>
+</head>
+
+<body class="bg-mustard-100">
+  <main class=" text-black-900 px-2 py-6 sm:p-6 sm:min-h-[100vh] sm:w-[100vw] overflow-x-hidden">
+    <header class="hidden sm:block">
+      <img src="webAssets/logoOnWhite.svg" alt="Webring light theme logo" />
+    </header>
+    <div class="sm:hidden fixed top-6 left-0 w-full px-2">
+      <input type="text" id="search-mobile" placeholder="Search by name, year or url..."
+        class=" w-full font-latinMonoCaps px-4 py-2 border border-lime-700 rounded-none" />
+    </div>
+    <div class="w-full sm:w-3/5 lg:w-2/5">
+      <p class="hidden sm:block font-latinRoman mt-10 leading-tight">
+        Welcome to the official webring of students studying CS at the
+        <a class="text-mustard-500 underline" href="https://uwaterloo.ca/" target="_blank">University of Waterloo</a>
+        in Ontario, Canada. This is an ongoing project to document one of the most talented student bodies in the world,
+        all while making them more visible to the public.
+      </p>
+      <p class="hidden sm:block font-latinRoman mt-4 leading-tight">
+        If you're one of us, we welcome you with open arms
+        (or in this case, open
+        <a class="text-mustard-500 underline" href="https://github.com/JusGu/uwatering">open PRs</a>).
+      </p>
+      <div>
+        <div class="grid grid-cols-12 sm:grid-cols-6 gap-3 sm:gap-6 mb-6 mt-16">
+          <span
+            class="col-span-5 sm:col-span-3 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">NAME</span>
+          <span
+            class="col-span-2 sm:col-span-1 text-right font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">YEAR</span>
+          <span
+            class="col-span-5 sm:col-span-2 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">URL</span>
+        </div>
+        <div class="w-full flex-flex-col space-y-1 text-sm sm:text-base" id="webring-list">
+        </div>
       </div>
-      <div class="w-full sm:w-3/5 lg:w-2/5">
-        <p class="hidden sm:block font-latinRoman mt-10 leading-tight">
-          Welcome to the official webring of students studying CS at the
-          <a
-            class="text-mustard-500 underline"
-            href="https://uwaterloo.ca/"
-            target="_blank"
-            >University of Waterloo</a
-          >
-          in Ontario, Canada. This is an ongoing project to document one of the
-          most talented student bodies in the world, all while making them more
-          visible to the public.
+    </div>
+
+    <div class="hidden fixed bottom-0 right-0 z-10 w-full p-6 lg:w-1/2 sm:flex flex-col space-y-2">
+      <input type="text" id="search" placeholder="Search by name, year or url..."
+        class="font-latinMonoCaps px-4 py-2 border border-navy-400/50" />
+      <div id="webring-chart" class="border border-navy-400/50">
+        <div id="chart-container" class="h-[24rem] lg:h-[32rem]"></div>
+      </div>
+    </div>
+
+    <footer x-data="{ open: true }"
+      class="fixed bottom-0 left-0 w-full sm:hidden bg-white border-t border-black-800 pt-4 pb-6 px-2">
+      <div @click="open = ! open" class="flex justify-between">
+        <button class="font-latinMonoRegular text-b202020lack-900 flex space-x-2 items-center">
+          <img src="webAssets/icons/expand.svg" alt="Expand info symbol" />
+          <span x-text="open ? 'CLOSE' : 'MORE INFO'"></span>
+        </button>
+        <div class="flex space-x-4 leading-none">
+          <a href="https://en.wikipedia.org/wiki/Webring"
+            class="font-latinMonoCondOblique text-lime-700 underline italic">what's a webring?</a>
+          <a href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
+            class="font-latinMonoCondOblique text-lime-700 underline italic">how can i join?</a>
+        </div>
+      </div>
+
+      <div x-show="open" class="w-full mt-8">
+        <p class="w-full font-latinMonoRegular leading-none">
+          We are computer science students and alumni studying at the <a class="text-mustard-500 underline"
+            href="https://uwaterloo.ca/">University of
+            Waterloo</a> in Ontario, Canada. If you're one of us, we welcome you with open arms. (Or in this case, open
+          <a class="text-mustard-500 underline" href="https://github.com/JusGu/uwatering">open PRs</a>).
         </p>
-        <p class="hidden sm:block font-latinRoman mt-4 leading-tight">
-          If you're one of us, we welcome you with open arms (or in this case,
-          open
-          <a
-            class="text-mustard-500 underline"
-            href="https://github.com/JusGu/uwatering"
-            >open PRs</a
-          >).
-        </p>
-        <div>
-          <div
-            class="grid grid-cols-12 sm:grid-cols-6 gap-3 sm:gap-6 mb-6 mt-16"
-          >
-            <span
-              class="col-span-5 sm:col-span-3 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic"
-              >NAME</span
-            >
-            <span
-              class="col-span-2 sm:col-span-1 text-right font-latinRomanDunhillOblique text-burgundy-500 text-lg italic"
-              >YEAR</span
-            >
-            <span
-              class="col-span-5 sm:col-span-2 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic"
-              >URL</span
-            >
-          </div>
-          <div
-            class="w-full flex-flex-col space-y-1 text-sm sm:text-base"
-            id="webring-list"
-          ></div>
+        <div id="webring-chart-mobile" class="w-full border border-black-900 mt-4">
+          <div id="chart-container-mobile" class="h-[12rem]"></div>
         </div>
       </div>
 
-      <div
-        class="hidden fixed bottom-0 right-0 z-10 w-full p-6 lg:w-1/2 sm:flex flex-col space-y-2"
-      >
-        <input
-          type="text"
-          id="search"
-          placeholder="Search by name, year or url..."
-          class="font-latinMonoCaps px-4 py-2 border border-navy-400/50"
-        />
-        <div id="webring-chart" class="border border-navy-400/50">
-          <div id="chart-container" class="h-[24rem] lg:h-[32rem]"></div>
-        </div>
-      </div>
+      <img src="webAssets/logoOnWhite.svg" class="mt-4" alt="Webring light theme logo" />
+    </footer>
 
-      <footer
-        x-data="{ open: true }"
-        class="fixed bottom-0 left-0 w-full sm:hidden bg-white border-t border-black-800 pt-4 pb-6 px-2"
-      >
-        <div @click="open = ! open" class="flex justify-between">
-          <button
-            class="font-latinMonoRegular text-b202020lack-900 flex space-x-2 items-center"
-          >
-            <img src="webAssets/icons/expand.svg" alt="Expand info symbol" />
-            <span x-text="open ? 'CLOSE' : 'MORE INFO'"></span>
-          </button>
-          <div class="flex space-x-4 leading-none">
-            <a
-              href="https://en.wikipedia.org/wiki/Webring"
-              class="font-latinMonoCondOblique text-lime-700 underline italic"
-              >what's a webring?</a
-            >
-            <a
-              href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
-              class="font-latinMonoCondOblique text-lime-700 underline italic"
-              >how can i join?</a
-            >
-          </div>
-        </div>
+    <div class="hidden sm:flex fixed top-6 right-6 flex-col itembs-end leading-none z-10">
+      <a href="https://en.wikipedia.org/wiki/Webring"
+        class="font-latinMonoCondOblique text-lime-400 underline italic">what's a webring?</a>
+      <a href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
+        class="font-latinMonoCondOblique text-lime-400 underline italic">how can i join?</a>
+    </div>
 
-        <div x-show="open" class="w-full mt-8">
-          <p class="w-full font-latinMonoRegular leading-none">
-            We are computer science students and alumni studying at the
-            <a class="text-mustard-500 underline" href="https://uwaterloo.ca/"
-              >University of Waterloo</a
-            >
-            in Ontario, Canada. If you're one of us, we welcome you with open
-            arms. (Or in this case, open
-            <a
-              class="text-mustard-500 underline"
-              href="https://github.com/JusGu/uwatering"
-              >open PRs</a
-            >).
-          </p>
-          <div
-            id="webring-chart-mobile"
-            class="w-full border border-black-900 mt-4"
-          >
-            <div id="chart-container-mobile" class="h-[12rem]"></div>
-          </div>
-        </div>
-
-        <img
-          src="webAssets/logoOnWhite.svg"
-          class="mt-4"
-          alt="Webring light theme logo"
-        />
-      </footer>
-
-      <div
-        class="hidden sm:flex fixed top-6 right-6 flex-col itembs-end leading-none z-10"
-      >
-        <a
-          href="https://en.wikipedia.org/wiki/Webring"
-          class="font-latinMonoCondOblique text-lime-400 underline italic"
-          >what's a webring?</a
-        >
-        <a
-          href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
-          class="font-latinMonoCondOblique text-lime-400 underline italic"
-          >how can i join?</a
-        >
-      </div>
-
-      <div class="fixed -top-4 sm:-top-12 -right-80 sm:-right-96 -z-10">
-        <pre
-          class="font-lion leading-tight sm:text-[1.25rem] sm:leading-[1.51rem] text-mustard-400"
-        >
+    <div class="fixed -top-4 sm:-top-12 -right-80 sm:-right-96 -z-10">
+      <pre class="font-lion leading-tight sm:text-[1.25rem] sm:leading-[1.51rem] text-mustard-400">
       ░░░░      ░░                                                         ░░░░░░░░░░░░                                                                                                                           
       ░░░░░░   ░░░░                                    ░░░░░░░░░░░░░░░░░                                                         ░░░░░░░░░░░░                              
          ░░░░░░░░░░                              ░░░░░░░░░░░░░░░░░                                                      ░░░░░░░░░░░░░░░░░░░░░            
@@ -325,9 +244,9 @@
                                                                   ░░░░░░░   ░░░                                                                                                                                                      
                                                                   ░░░░░                  
    
-    </pre
-        >
-      </div>
-    </main>
-  </body>
+    </pre>
+    </div>
+  </main>
+</body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -1,211 +1,292 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="./css/output.css" rel="stylesheet" />
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="./css/output.css" rel="stylesheet" />
+    <!-- prevent visible alpinejs page reloading -->
+    <style>
+      [x-cloak] {
+        display: none;
+      }
+    </style>
 
-  <!-- prevent visible alpinejs page reloading -->
-  <style>
-    [x-cloak] {
-      display: none;
-    }
-  </style>
+    <!-- SEO Meta Tags -->
+    <title>CS Webring</title>
+    <meta
+      name="description"
+      content="A webring for Computer Science students and alumni at the University of Waterloo."
+    />
+    <meta
+      name="keywords"
+      content="webring, UWaterloo, Computer Science, CS, personal websites, student portfolio"
+    />
 
-  <!-- SEO Meta Tags -->
-  <title>CS Webring</title>
-  <meta name="description" content="A webring for Computer Science students and alumni at the University of Waterloo.">
-  <meta name="keywords" content="webring, UWaterloo, Computer Science, CS, personal websites, student portfolio">
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://cs.uwatering.com/" />
+    <meta property="og:title" content="CS Webring" />
+    <meta
+      property="og:description"
+      content="A webring for Computer Science students and alumni at the University of Waterloo."
+    />
+    <meta
+      property="og:image"
+      content="https://cs.uwatering.com/webAssets/og.png"
+    />
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://cs.uwatering.com/" />
+    <meta property="twitter:title" content="CS Webring" />
+    <meta
+      property="twitter:description"
+      content="A webring for Computer Science students and alumni at the University of Waterloo."
+    />
+    <meta
+      property="twitter:image"
+      content="https://cs.uwatering.com/webAssets/og.png"
+    />
 
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://cs.uwatering.com/">
-  <meta property="og:title" content="CS Webring">
-  <meta property="og:description"
-    content="A webring for Computer Science students and alumni at the University of Waterloo.">
-  <meta property="og:image" content="https://cs.uwatering.com/webAssets/og.png">
-  <!-- Twitter -->
-  <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://cs.uwatering.com/">
-  <meta property="twitter:title" content="CS Webring">
-  <meta property="twitter:description"
-    content="A webring for Computer Science students and alumni at the University of Waterloo.">
-  <meta property="twitter:image" content="https://cs.uwatering.com/webAssets/og.png">
+    <!-- Favicon -->
+    <link rel="icon" type="image/x-icon" href="./webAssets/favicon.ico" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/x-icon" href="./webAssets/favicon.ico">
+    <!-- JS sources -->
+    <script src="//unpkg.com/alpinejs" defer></script>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <!-- ↓↓↓ OPEN THIS GUY UP ↓↓↓ -->
+    <script>
+      const webringData = {
+        sites: [
+          {
+            name: "Justin Gu",
+            year: 2026,
+            website: "https://justin.run",
+          },
+          {
+            name: "Jaiden Ratti",
+            year: 2026,
+            website: "https://www.jaidenratti.com/",
+          },
+          {
+            name: "George Shao",
+            year: 2026,
+            website: "https://shao.zip",
+          },
+          {
+            name: "Jaryd Diamond",
+            year: 2026,
+            website: "https://jaryddiamond.com",
+          },
+          {
+            name: "Ivy Fan-Chiang",
+            year: 2027,
+            website: "https://ivyfanchiang.ca",
+          },
+          {
+            name: "Wilbur Zhang",
+            year: 2026,
+            website: "https://wilburzhang.com",
+          },
+          // TODO: allow search to work with trailing slash
+          {
+            name: "Ching Lam Lau",
+            year: 2029,
+            website: "https://chinglamlau.ca",
+          },
+          {
+            name: "Martin Sit",
+            year: 2029,
+            website: "https://martinsit.ca/",
+          },
+          {
+            name: "Kevin Huang",
+            year: 2026,
+            website: "https://kevinh.cv",
+          },
+          {
+            name: "Freeman Jiang",
+            year: 2026,
+            website: "https://freemanjiang.com",
+          },
+          {
+            name: "Aryaman Dhingra",
+            year: 2025,
+            website: "https://aryaman.dev",
+          },
+          {
+            name: "gaurav talreja",
+            year: 2025,
+            website: "https://gaurav.fyi",
+          },
+          {
+            name: "Dundee Zhang",
+            website: "https://dundeezhang.com",
+            year: "2029",
+          },
+          {
+            name: "Sean Zhang",
+            website: "https://seanzhang.ca",
+            year: 2024,
+          },
+          // ↑ ADD YOUR SITE ABOVE ↑
+          // https://github.com/JusGu/uwatering
+        ],
+      };
+    </script>
+    <!-- ↑↑↑ -->
+    <script src="./javascript/script.js"></script>
+    <script src="./javascript/d3-ring-chart.js"></script>
+  </head>
 
-  <!-- JS sources -->
-  <script src="//unpkg.com/alpinejs" defer></script>
-  <script src="https://d3js.org/d3.v7.min.js"></script>
-  <!-- ↓↓↓ OPEN THIS GUY UP ↓↓↓ -->
-  <script>
-    const webringData = {
-      "sites": [
-        {
-          "name": "Justin Gu",
-          "year": 2026,
-          "website": "https://justin.run"
-        },
-        {
-          "name": "Jaiden Ratti",
-          "year": 2026,
-          "website": "https://www.jaidenratti.com/"
-        },
-        {
-          "name": "George Shao",
-          "year": 2026,
-          "website": "https://shao.zip"
-        },
-        {
-          "name": "Jaryd Diamond",
-          "year": 2026,
-          "website": "https://jaryddiamond.com"
-        },
-        {
-          "name": "Ivy Fan-Chiang",
-          "year": 2027,
-          "website": "https://ivyfanchiang.ca"
-        },
-        {
-          "name": "Wilbur Zhang",
-          "year": 2026,
-          "website": "https://wilburzhang.com"
-        },
-        // TODO: allow search to work with trailing slash
-        {
-          "name": "Ching Lam Lau",
-          "year": 2029,
-          "website": "https://chinglamlau.ca"
-        },
-        {
-          "name": "Martin Sit",
-          "year": 2029,
-          "website": "https://martinsit.ca/"
-        },
-        {
-          "name": "Kevin Huang",
-          "year": 2026,
-          "website": "https://kevinh.cv"
-        },
-        {
-          "name": "Freeman Jiang",
-          "year": 2026,
-          "website": "https://freemanjiang.com"
-        },
-        {
-          "name": "Aryaman Dhingra",
-          "year": 2025,
-          "website": "https://aryaman.dev"
-        },
-        {
-          "name": "gaurav talreja",
-          "year": 2025,
-          "website": "https://gaurav.fyi"
-        },
-        {
-          "name": "Dundee Zhang",
-          "website": "https://dundeezhang.com",
-          "year": "2029"
-        },
-        {
-          "name": "Sean Zhang",
-          "website": "https://seanzhang.ca",
-          "year": 2024
-        },
-        // ↑ ADD YOUR SITE ABOVE ↑
-        // https://github.com/JusGu/uwatering
-      ]
-    };
-  </script>
-  <!-- ↑↑↑ -->
-  <script src="./javascript/script.js"></script>
-  <script src="./javascript/d3-ring-chart.js"></script>
-</head>
-
-<body class="bg-mustard-100">
-  <main class=" text-black-900 px-2 py-6 sm:p-6 sm:min-h-[100vh] sm:w-[100vw] overflow-x-hidden">
-    <header class="hidden sm:block">
-      <img src="webAssets/logoOnWhite.svg" alt="Webring light theme logo" />
-    </header>
-    <div class="sm:hidden fixed top-6 left-0 w-full px-2">
-      <input type="text" id="search-mobile" placeholder="Search by name, year or url..."
-        class=" w-full font-latinMonoCaps px-4 py-2 border border-lime-700 rounded-none" />
-    </div>
-    <div class="w-full sm:w-3/5 lg:w-2/5">
-      <p class="hidden sm:block font-latinRoman mt-10 leading-tight">
-        Welcome to the official webring of students studying CS at the
-        <a class="text-mustard-500 underline" href="https://uwaterloo.ca/" target="_blank">University of Waterloo</a>
-        in Ontario, Canada. This is an ongoing project to document one of the most talented student bodies in the world,
-        all while making them more visible to the public.
-      </p>
-      <p class="hidden sm:block font-latinRoman mt-4 leading-tight">
-        If you're one of us, we welcome you with open arms
-        (or in this case, open
-        <a class="text-mustard-500 underline" href="https://github.com/JusGu/uwatering">open PRs</a>).
-      </p>
-      <div>
-        <div class="grid grid-cols-12 sm:grid-cols-6 gap-3 sm:gap-6 mb-6 mt-16">
-          <span
-            class="col-span-5 sm:col-span-3 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">NAME</span>
-          <span
-            class="col-span-2 sm:col-span-1 text-right font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">YEAR</span>
-          <span
-            class="col-span-5 sm:col-span-2 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">URL</span>
-        </div>
-        <div class="w-full flex-flex-col space-y-1 text-sm sm:text-base" id="webring-list">
-        </div>
+  <body class="bg-mustard-100">
+    <main
+      class="text-black-900 px-2 py-6 sm:p-6 sm:min-h-[100vh] sm:w-[100vw] overflow-x-hidden"
+    >
+      <header class="hidden sm:block">
+        <img src="webAssets/logoOnWhite.svg" alt="Webring light theme logo" />
+      </header>
+      <div class="sm:hidden fixed top-6 left-0 w-full px-2">
+        <input
+          type="text"
+          id="search-mobile"
+          placeholder="Search by name, year or url..."
+          class="w-full font-latinMonoCaps px-4 py-2 border border-lime-700 rounded-none"
+        />
       </div>
-    </div>
-
-    <div class="hidden fixed bottom-0 right-0 z-10 w-full p-6 lg:w-1/2 sm:flex flex-col space-y-2">
-      <input type="text" id="search" placeholder="Search by name, year or url..."
-        class="font-latinMonoCaps px-4 py-2 border border-navy-400/50" />
-      <div id="webring-chart" class="border border-navy-400/50">
-        <div id="chart-container" class="h-[24rem] lg:h-[32rem]"></div>
-      </div>
-    </div>
-
-    <footer x-data="{ open: true }"
-      class="fixed bottom-0 left-0 w-full sm:hidden bg-white border-t border-black-800 pt-4 pb-6 px-2">
-      <div @click="open = ! open" class="flex justify-between">
-        <button class="font-latinMonoRegular text-b202020lack-900 flex space-x-2 items-center">
-          <img src="webAssets/icons/expand.svg" alt="Expand info symbol" />
-          <span x-text="open ? 'CLOSE' : 'MORE INFO'"></span>
-        </button>
-        <div class="flex space-x-4 leading-none">
-          <a href="https://en.wikipedia.org/wiki/Webring"
-            class="font-latinMonoCondOblique text-lime-700 underline italic">what's a webring?</a>
-          <a href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
-            class="font-latinMonoCondOblique text-lime-700 underline italic">how can i join?</a>
-        </div>
-      </div>
-
-      <div x-show="open" class="w-full mt-8">
-        <p class="w-full font-latinMonoRegular leading-none">
-          We are computer science students and alumni studying at the <a class="text-mustard-500 underline"
-            href="https://uwaterloo.ca/">University of
-            Waterloo</a> in Ontario, Canada. If you're one of us, we welcome you with open arms. (Or in this case, open
-          <a class="text-mustard-500 underline" href="https://github.com/JusGu/uwatering">open PRs</a>).
+      <div class="w-full sm:w-3/5 lg:w-2/5">
+        <p class="hidden sm:block font-latinRoman mt-10 leading-tight">
+          Welcome to the official webring of students studying CS at the
+          <a
+            class="text-mustard-500 underline"
+            href="https://uwaterloo.ca/"
+            target="_blank"
+            >University of Waterloo</a
+          >
+          in Ontario, Canada. This is an ongoing project to document one of the
+          most talented student bodies in the world, all while making them more
+          visible to the public.
         </p>
-        <div id="webring-chart-mobile" class="w-full border border-black-900 mt-4">
-          <div id="chart-container-mobile" class="h-[12rem]"></div>
+        <p class="hidden sm:block font-latinRoman mt-4 leading-tight">
+          If you're one of us, we welcome you with open arms (or in this case,
+          open
+          <a
+            class="text-mustard-500 underline"
+            href="https://github.com/JusGu/uwatering"
+            >open PRs</a
+          >).
+        </p>
+        <div>
+          <div
+            class="grid grid-cols-12 sm:grid-cols-6 gap-3 sm:gap-6 mb-6 mt-16"
+          >
+            <span
+              class="col-span-5 sm:col-span-3 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic"
+              >NAME</span
+            >
+            <span
+              class="col-span-2 sm:col-span-1 text-right font-latinRomanDunhillOblique text-burgundy-500 text-lg italic"
+              >YEAR</span
+            >
+            <span
+              class="col-span-5 sm:col-span-2 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic"
+              >URL</span
+            >
+          </div>
+          <div
+            class="w-full flex-flex-col space-y-1 text-sm sm:text-base"
+            id="webring-list"
+          ></div>
         </div>
       </div>
 
-      <img src="webAssets/logoOnWhite.svg" class="mt-4" alt="Webring light theme logo" />
-    </footer>
+      <div
+        class="hidden fixed bottom-0 right-0 z-10 w-full p-6 lg:w-1/2 sm:flex flex-col space-y-2"
+      >
+        <input
+          type="text"
+          id="search"
+          placeholder="Search by name, year or url..."
+          class="font-latinMonoCaps px-4 py-2 border border-navy-400/50"
+        />
+        <div id="webring-chart" class="border border-navy-400/50">
+          <div id="chart-container" class="h-[24rem] lg:h-[32rem]"></div>
+        </div>
+      </div>
 
-    <div class="hidden sm:flex fixed top-6 right-6 flex-col itembs-end leading-none z-10">
-      <a href="https://en.wikipedia.org/wiki/Webring"
-        class="font-latinMonoCondOblique text-lime-400 underline italic">what's a webring?</a>
-      <a href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
-        class="font-latinMonoCondOblique text-lime-400 underline italic">how can i join?</a>
-    </div>
+      <footer
+        x-data="{ open: true }"
+        class="fixed bottom-0 left-0 w-full sm:hidden bg-white border-t border-black-800 pt-4 pb-6 px-2"
+      >
+        <div @click="open = ! open" class="flex justify-between">
+          <button
+            class="font-latinMonoRegular text-b202020lack-900 flex space-x-2 items-center"
+          >
+            <img src="webAssets/icons/expand.svg" alt="Expand info symbol" />
+            <span x-text="open ? 'CLOSE' : 'MORE INFO'"></span>
+          </button>
+          <div class="flex space-x-4 leading-none">
+            <a
+              href="https://en.wikipedia.org/wiki/Webring"
+              class="font-latinMonoCondOblique text-lime-700 underline italic"
+              >what's a webring?</a
+            >
+            <a
+              href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
+              class="font-latinMonoCondOblique text-lime-700 underline italic"
+              >how can i join?</a
+            >
+          </div>
+        </div>
 
-    <div class="fixed -top-4 sm:-top-12 -right-80 sm:-right-96 -z-10">
-      <pre class="font-lion leading-tight sm:text-[1.25rem] sm:leading-[1.51rem] text-mustard-400">
+        <div x-show="open" class="w-full mt-8">
+          <p class="w-full font-latinMonoRegular leading-none">
+            We are computer science students and alumni studying at the
+            <a class="text-mustard-500 underline" href="https://uwaterloo.ca/"
+              >University of Waterloo</a
+            >
+            in Ontario, Canada. If you're one of us, we welcome you with open
+            arms. (Or in this case, open
+            <a
+              class="text-mustard-500 underline"
+              href="https://github.com/JusGu/uwatering"
+              >open PRs</a
+            >).
+          </p>
+          <div
+            id="webring-chart-mobile"
+            class="w-full border border-black-900 mt-4"
+          >
+            <div id="chart-container-mobile" class="h-[12rem]"></div>
+          </div>
+        </div>
+
+        <img
+          src="webAssets/logoOnWhite.svg"
+          class="mt-4"
+          alt="Webring light theme logo"
+        />
+      </footer>
+
+      <div
+        class="hidden sm:flex fixed top-6 right-6 flex-col itembs-end leading-none z-10"
+      >
+        <a
+          href="https://en.wikipedia.org/wiki/Webring"
+          class="font-latinMonoCondOblique text-lime-400 underline italic"
+          >what's a webring?</a
+        >
+        <a
+          href="https://github.com/JusGu/uwatering?tab=readme-ov-file#join-the-webring"
+          class="font-latinMonoCondOblique text-lime-400 underline italic"
+          >how can i join?</a
+        >
+      </div>
+
+      <div class="fixed -top-4 sm:-top-12 -right-80 sm:-right-96 -z-10">
+        <pre
+          class="font-lion leading-tight sm:text-[1.25rem] sm:leading-[1.51rem] text-mustard-400"
+        >
       ░░░░      ░░                                                         ░░░░░░░░░░░░                                                                                                                           
       ░░░░░░   ░░░░                                    ░░░░░░░░░░░░░░░░░                                                         ░░░░░░░░░░░░                              
          ░░░░░░░░░░                              ░░░░░░░░░░░░░░░░░                                                      ░░░░░░░░░░░░░░░░░░░░░            
@@ -244,9 +325,9 @@
                                                                   ░░░░░░░   ░░░                                                                                                                                                      
                                                                   ░░░░░                  
    
-    </pre>
-    </div>
-  </main>
-</body>
-
+    </pre
+        >
+      </div>
+    </main>
+  </body>
 </html>


### PR DESCRIPTION
I found that on tablet screens, the graph would cover up the webring links as the graph expanded to take up the width of the screen. Thus, much text such as the names, websites becoming like this: 
![image](https://github.com/user-attachments/assets/8f305b71-f15a-4f1b-a4fe-6efd7c281b1c)

I edited a single CSS line (others are my auto formatter) to make the CSS switch to the mobile layout (currently at 640px) at 1024px, the same time the graph takes up half the screen. Thus, the sites will be covered by a collapsable graph rather than a floating one that covers all the information.

Below is a video demo of what I mean.

https://github.com/user-attachments/assets/bde2db00-e2a7-4e7e-a81f-1b579a84b893

