### PR TITLE
less obstructive mobile footer

### DIFF
--- a/css/output.css
+++ b/css/output.css
@@ -725,6 +725,38 @@ video {
   margin-top: 2rem;
 }
 
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mb-\[100rem\] {
+  margin-bottom: 100rem;
+}
+
+.mb-32 {
+  margin-bottom: 8rem;
+}
+
+.mb-24 {
+  margin-bottom: 6rem;
+}
+
+.block {
+  display: block;
+}
+
 .flex {
   display: flex;
 }
@@ -743,6 +775,18 @@ video {
 
 .h-\[24rem\] {
   height: 24rem;
+}
+
+.h-2 {
+  height: 0.5rem;
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.h-6 {
+  height: 1.5rem;
 }
 
 .min-h-\[100vh\] {
@@ -823,10 +867,6 @@ video {
   border-radius: 0px;
 }
 
-.rounded-sm {
-  border-radius: 0.125rem;
-}
-
 .border {
   border-width: 1px;
 }
@@ -859,14 +899,9 @@ video {
   background-color: rgb(255 252 247 / var(--tw-bg-opacity, 1));
 }
 
-.text-mustard-100 {
-  --tw-text-opacity: 1;
-  color: rgb(255 252 247 / var(--tw-bg-opacity, 1));
-}
-
-.bg-navy-400 {
+.bg-mustard-500 {
   --tw-bg-opacity: 1;
-  background-color: rgb(73 119 161 / var(--tw-bg-opacity, 1));
+  background-color: rgb(178 101 0 / var(--tw-bg-opacity, 1));
 }
 
 .bg-white {
@@ -898,12 +933,24 @@ video {
   padding-bottom: 1.5rem;
 }
 
-.pb-6 {
-  padding-bottom: 1.5rem;
+.pb-4 {
+  padding-bottom: 1rem;
 }
 
 .pt-4 {
   padding-top: 1rem;
+}
+
+.pb-0 {
+  padding-bottom: 0px;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
 }
 
 .text-left {
@@ -984,6 +1031,11 @@ video {
   color: rgb(72 85 33 / var(--tw-text-opacity, 1));
 }
 
+.text-mustard-100 {
+  --tw-text-opacity: 1;
+  color: rgb(255 252 247 / var(--tw-text-opacity, 1));
+}
+
 .text-mustard-400 {
   --tw-text-opacity: 1;
   color: rgb(218 173 48 / var(--tw-text-opacity, 1));
@@ -992,15 +1044,6 @@ video {
 .text-mustard-500 {
   --tw-text-opacity: 1;
   color: rgb(178 101 0 / var(--tw-text-opacity, 1));
-}
-
-.bg-mustard-500 {
-  background-color: rgb(178 101 0 / var(--tw-bg-opacity, 1));
-}
-
-.text-white {
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
 .underline {
@@ -1019,7 +1062,7 @@ video {
   transition-duration: 150ms;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 640px) {
   .sm\:-right-96 {
     right: -24rem;
   }
@@ -1038,6 +1081,10 @@ video {
 
   .sm\:col-span-3 {
     grid-column: span 3 / span 3;
+  }
+
+  .sm\:mb-0 {
+    margin-bottom: 0px;
   }
 
   .sm\:block {

--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@
           <span
             class="col-span-5 sm:col-span-2 text-left font-latinRomanDunhillOblique text-burgundy-500 text-lg italic">URL</span>
         </div>
-        <div class="w-full flex-flex-col space-y-1 text-sm sm:text-base" id="webring-list">
+        <div class="w-full flex-flex-col space-y-1 text-sm sm:text-base mb-24 sm:mb-0" id="webring-list">
         </div>
       </div>
     </div>
@@ -238,7 +238,7 @@
     </div>
 
     <footer x-data="{ open: true }"
-      class="fixed bottom-0 left-0 w-full sm:hidden bg-white border-t border-black-800 pt-4 pb-6 px-2">
+      class="fixed bottom-0 left-0 w-full sm:hidden bg-white border-t border-black-800 pt-4 pb-3 px-2">
       <div @click="open = ! open" class="flex justify-between">
         <button class="font-latinMonoRegular text-b202020lack-900 flex space-x-2 items-center">
           <img src="webAssets/icons/expand.svg" alt="Expand info symbol" />
@@ -252,7 +252,7 @@
         </div>
       </div>
 
-      <div x-show="open" class="w-full mt-8">
+      <div x-show="open" class="w-full mt-8 mb-6">
         <p class="w-full font-latinMonoRegular leading-none">
           We are computer science students and alumni studying at the <a class="text-mustard-500 underline"
             href="https://uwaterloo.ca/">University of
@@ -264,7 +264,7 @@
         </div>
       </div>
 
-      <img src="webAssets/logoOnWhite.svg" class="mt-4" alt="Webring light theme logo" />
+      <img src="webAssets/logoOnWhite.svg" class="mt-2 h-6" alt="Webring light theme logo" />
     </footer>
 
     <div class="hidden sm:flex fixed top-6 right-6 flex-col itembs-end leading-none z-10">


### PR DESCRIPTION
- shrunk mobile footer cause it felt a bit too clunky 
- the last few names were getting obstructed cause of bad margin styling, that is fixed now

| Before      | After |
| ----------- | ----------- |
| <img width="477" alt="image" src="https://github.com/user-attachments/assets/3361e32d-0c4e-409c-b003-3506a86b73f2" />      | <img width="454" alt="image" src="https://github.com/user-attachments/assets/df497a65-3b40-4449-9b05-31036965d76e" />       |


