### PR TITLE
Add Mars Xiang to the webring

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,6 +623,11 @@
           "name": "Andy S. Yu",
           "website": "https://andyyyyuuu.github.io",
           "year": "2030"
+        },
+        {
+          "name": "Mars Xiang",
+          "website": "https://marsxiang.com",
+          "year": "2028"
         }
         // ↑ ADD YOUR SITE ABOVE ↑
         // https://github.com/JusGu/uwatering


### PR DESCRIPTION
Website Link: https://marsxiang.com

- **Name:** Mars Xiang
- **Website:** https://marsxiang.com
- **Year:** 2028

The widget is on the home page, but it's tucked into a hover popup rather than a footer — hover "University of Waterloo" in the intro paragraph and the lion with the prev/next arrows appears above it. It's also reachable by keyboard (tab to the underlined text). Happy to move it somewhere more conventional if you'd prefer it visible by default.

Thanks for maintaining this!